### PR TITLE
Add technical debt log items and template

### DIFF
--- a/assumptions/cli.py
+++ b/assumptions/cli.py
@@ -63,7 +63,13 @@ def cli():
     # Generate log
     log = Log(args.log_type, outfile)
 
-    for item_type_class in _BUILTIN_ITEM_TYPES[args.log_type]:
+    item_types = _BUILTIN_ITEM_TYPES.get(args.log_type)
+    if item_types is None:
+        raise ValueError(
+            f"{args.log_type} is not a build in log type. Try one of: {','.join(_BUILTIN_ITEM_TYPES.keys())}",
+        )
+
+    for item_type_class in item_types:
         log.add_log_item_type(item_type_class)
 
     log.find_items(args.path, args.extension)

--- a/assumptions/log.py
+++ b/assumptions/log.py
@@ -7,6 +7,7 @@ import pkg_resources
 
 from assumptions.log_items import Assumption
 from assumptions.log_items import Caveat
+from assumptions.log_items import Debt
 from assumptions.log_items import LogItem
 from assumptions.log_items import Todo
 
@@ -21,6 +22,7 @@ class LogFindError(Exception):
 
 _BUILTIN_ITEM_TYPES = {
     "assumptions_caveats_log": [Assumption, Caveat],
+    "technical_debt_log": [Debt],
     "todo_list": [Todo],
 }
 

--- a/assumptions/log_items.py
+++ b/assumptions/log_items.py
@@ -231,6 +231,52 @@ class Caveat(LogItem):
         return caveat_content
 
 
+class Debt(LogItem):
+    """
+    Matches and parses technical debt items from hash code comments.
+    """
+
+    search_patterns = [
+        (
+            # Get indentation level and title
+            r"^([ \t]*)# ?Debt: (.+)\n?"
+            # Lazily match everything following, till there's a line that doesn't start
+            # with the same indent and comment
+            r"(\1# ?(?:.|\n)*?)^(?!\1#)"
+        ),
+    ]
+
+    template_marker = "{ debt }"
+    empty_message = "Looks like we're debt free!\n"
+
+    def parse(self, idx, file_path, item):
+        debt_item = re.sub(
+            # Remove indentation and comment hash from todo item
+            f"\n?{item[0]}#",
+            "",
+            item[2],
+        )
+        debt_item = re.sub(
+            # Reduce whitespace to single spaces and strip
+            "[ ]{2,}",
+            " ",
+            debt_item.strip(),
+        )
+
+        debt_content = "\n".join(
+            [
+                f"### Debt {idx + 1}: {item[1]}",
+                "",
+                # Relative path to file
+                f"Location: `{file_path}`",
+                "",
+                f"{debt_item}",
+                "",
+            ],
+        )
+        return debt_content
+
+
 class Todo(LogItem):
     """
     Matches and parses todos from hash code comments.

--- a/assumptions/templates/technical_debt_log.md
+++ b/assumptions/templates/technical_debt_log.md
@@ -1,0 +1,13 @@
+# Technical debt log
+
+[Technical debt](https://en.wikipedia.org/wiki/Technical_debt) is the consequence of poor design decisions, which may or may not be intentional. The consequences of this debt can include code being more difficult to extend, maintain or test.
+
+Up to date documentation of technical debt can help to identify and prioritise improvements that will benefit ongoing development of the project.
+
+## Technical debt
+
+Technical debt log last updated: { current_date }
+
+This project has incurred the following debt:
+
+{ debt }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,17 @@ def pre_build_handler(app, config):
             "-e",
             ".py",
             "-o",
+            f"{app.srcdir}/example/technical_debt_log.md",
+            "-l",
+            "technical_debt_log",
+        ],
+    )
+    subprocess.run(
+        [
+            "assumptions",
+            "-e",
+            ".py",
+            "-o",
             f"{app.srcdir}/example/todo_list.md",
             "-l",
             "todo_list",

--- a/docs/source/customising/log_templates.rst
+++ b/docs/source/customising/log_templates.rst
@@ -16,6 +16,13 @@ The default template displays a list of assumptions and caveats. It also indicat
 .. literalinclude:: ../../../assumptions/templates/assumptions_caveats_log.md
 
 
+Technical debt log
+------------------
+
+This basic template creates a Markdown checklist from technical debt items that have been recorded in comments in your code.
+
+.. literalinclude:: ../../../assumptions/templates/technical_debt_log.md
+
 Todo list
 ---------
 

--- a/docs/source/example/index.rst
+++ b/docs/source/example/index.rst
@@ -9,6 +9,7 @@ This sections demonstrates what output logs look like when included in documenta
     :hidden:
 
     assumptions_caveats_log.md
+    technical_debt_log.md
     todo_list.md
 
 Assumptions and caveats log
@@ -19,6 +20,15 @@ The `example assumtions and caveats log <assumptions_caveats_log.html>`_ is gene
 .. code-block:: sh
 
     assumptions -e .py -o docs/source/example/assumptions_caveats_log.md
+
+Technical debt log
+------------------
+
+The `example technical debt log <technical_debt_log.html>`_ is generated from the root of this project using:
+
+.. code-block:: sh
+
+    assumptions -e .py -o docs/source/example/technical_debt_log.md -l technical_debt_log
 
 Todo list
 ---------

--- a/docs/source/example_debt.py
+++ b/docs/source/example_debt.py
@@ -1,0 +1,3 @@
+# Debt: Hardcoded file paths
+# File paths are hard coded, so will need updating to run with new data.
+# Should move these to a configuration file.


### PR DESCRIPTION
Adds a new default log type for technical debt.

`Debt` items act similarly to `Caveats`.